### PR TITLE
Refactor dashboard layout with task list and module cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,91 +1,69 @@
 <!DOCTYPE html>
 <html lang="es">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sistema Modular - Inicio</title>
-    <link rel="stylesheet" href="./public/css/global.css">
-    <style>
-      body {
-        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-        margin: 0;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: linear-gradient(135deg, #0f172a, #1e293b);
-        color: #f8fafc;
-      }
-
-      .home-card {
-        background-color: rgba(15, 23, 42, 0.85);
-        border-radius: 16px;
-        padding: 40px;
-        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.6);
-        text-align: center;
-        max-width: 720px;
-      }
-
-      .home-card ul {
-        text-align: left;
-        margin: 0 0 24px;
-        padding-left: 20px;
-        line-height: 1.6;
-      }
-
-      .home-card li {
-        margin-bottom: 8px;
-      }
-
-      .home-card h1 {
-        margin-bottom: 18px;
-        font-size: 34px;
-      }
-
-      .home-card p {
-        margin-bottom: 24px;
-        line-height: 1.6;
-      }
-
-      .home-card a {
-        display: inline-block;
-        background: #38bdf8;
-        color: #0f172a;
-        padding: 12px 28px;
-        border-radius: 8px;
-        text-decoration: none;
-        font-weight: 600;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
-      }
-
-      .home-card a:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 12px 24px rgba(56, 189, 248, 0.4);
-      }
-    </style>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login - Sistema Modular</title>
+    <link rel="stylesheet" href="./public/css/global.css" />
+    <link rel="stylesheet" href="./modules/auth/css/login.css" />
   </head>
   <body>
-    <main class="home-card">
-      <h1>Bienvenido a tu Portal de Herramientas Empresariales</h1>
-      <p>
-        Este portal reúne en un solo lugar las principales aplicaciones que necesitas para gestionar
-        y hacer crecer tu negocio de manera ágil y profesional.
-      </p>
-      <p>
-        Desde aquí podrás acceder a diferentes módulos diseñados para cubrir áreas clave de tu organización:
-      </p>
-      <ul>
-        <li><strong>CRM:</strong> administra clientes, contactos y oportunidades de venta.</li>
-        <li><strong>Catálogo:</strong> organiza y presenta tu oferta de productos y servicios.</li>
-        <li><strong>Chatbot Web:</strong> brinda atención automática y disponible 24/7.</li>
-        <li><strong>Estrategias de Marketing:</strong> planifica y ejecuta campañas efectivas.</li>
-        <li><strong>Herramientas Extra:</strong> utilidades complementarias que facilitan la gestión diaria.</li>
-      </ul>
-      <p>
-        Cada módulo está pensado para integrarse en un sistema sencillo de usar, pero lo suficientemente robusto
-        para ayudarte a tomar decisiones basadas en datos y optimizar tus procesos.
-      </p>
-      <a href="./modules/auth/login.html">Iniciar sesión</a>
+    <main class="login-container">
+      <section class="login-card">
+        <header>
+          <h2>Acceso al Sistema</h2>
+          <p>Ingresa tus credenciales para continuar</p>
+        </header>
+        <form id="loginForm" novalidate>
+          <div class="form-group">
+            <label for="username">Usuario</label>
+            <input
+              type="text"
+              id="username"
+              name="username"
+              placeholder="usuario_profesional"
+              autocomplete="username"
+              required
+            />
+            <span class="feedback" id="usernameFeedback"></span>
+          </div>
+          <div class="form-group">
+            <label for="password">Contraseña</label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              placeholder="********"
+              autocomplete="current-password"
+              required
+            />
+            <span class="feedback" id="passwordFeedback"></span>
+          </div>
+          <div class="form-options">
+            <label class="checkbox">
+              <input type="checkbox" id="rememberMe" name="rememberMe" />
+              <span>Recordarme</span>
+            </label>
+            <a class="link" href="./modules/auth/register.html">Crear cuenta</a>
+          </div>
+          <button type="submit" class="primary-button">Ingresar</button>
+          <span class="feedback" id="generalFeedback"></span>
+        </form>
+        <section class="module-kpi" aria-live="polite">
+          <h3>Módulos activos</h3>
+          <article class="module-highlight" id="moduleHighlight">
+            <span class="module-icon" id="moduleIcon" aria-hidden="true"></span>
+            <div class="module-copy">
+              <span class="module-label">Mostrando:</span>
+              <span class="module-name" id="moduleName"></span>
+              <p class="module-description" id="moduleDescription"></p>
+            </div>
+          </article>
+        </section>
+      </section>
     </main>
+    <script type="module" src="./lib/supabaseClient.js"></script>
+    <script type="module" src="./lib/authGuard.js"></script>
+    <script type="module" src="./modules/auth/js/login.js"></script>
   </body>
 </html>

--- a/lib/authGuard.js
+++ b/lib/authGuard.js
@@ -2,6 +2,7 @@
 // Este módulo centraliza la lógica de autenticación y protección de rutas del sistema.
 
 import { gotoFromModule } from "./pathUtil.js";
+import { supabaseClient } from "./supabaseClient.js";
 
 const LOGIN_RELATIVE_PATH = "../modules/auth/login.html";
 const SESSION_STORAGE_KEY = "sistemaModularSesion";
@@ -93,4 +94,51 @@ export function getCurrentUser() {
     userId: session.userId ?? null,
     loginAt: session.loginAt ?? null
   };
+}
+
+// Obtiene el identificador del usuario autenticado desde la sesión o desde la base de datos.
+export async function resolveCurrentUserId(client = supabaseClient) {
+  const session = getStoredSession();
+
+  if (!session || !session.username) {
+    return null;
+  }
+
+  if (session.userId) {
+    return session.userId;
+  }
+
+  try {
+    const { data, error } = await client
+      .from("usuarios")
+      .select("id")
+      .eq("username", session.username)
+      .maybeSingle();
+
+    if (error) {
+      console.error("No fue posible obtener el id del usuario actual", error);
+      return null;
+    }
+
+    if (!data || !data.id) {
+      return null;
+    }
+
+    if (typeof window !== "undefined") {
+      const storageKey = SESSION_STORAGE_KEY;
+      const updatedSession = { ...session, userId: data.id };
+      const storedInLocal = window.localStorage.getItem(storageKey);
+
+      if (storedInLocal) {
+        window.localStorage.setItem(storageKey, JSON.stringify(updatedSession));
+      } else if (window.sessionStorage.getItem(storageKey)) {
+        window.sessionStorage.setItem(storageKey, JSON.stringify(updatedSession));
+      }
+    }
+
+    return data.id;
+  } catch (error) {
+    console.error("Error inesperado al resolver el id del usuario", error);
+    return null;
+  }
 }

--- a/modules/auth/css/login.css
+++ b/modules/auth/css/login.css
@@ -2,122 +2,111 @@
  * Estilos dedicados para la pantalla de inicio de sesión. */
 
 body {
-  background: linear-gradient(135deg, #0f172a, #1e293b);
+  background-color: var(--color-background, #ffffff);
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
+  color: #1f2937;
 }
-
 
 .login-container {
   width: 100%;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 32px;
-  align-items: stretch;
-  padding: 40px;
-  max-width: 1200px;
-  margin: 0 auto;
-}
-
-.login-overview {
-  background-color: rgba(15, 23, 42, 0.76);
-  padding: 36px;
-  border-radius: 24px;
-  box-shadow: 0 24px 55px rgba(8, 47, 73, 0.4);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-}
-
-.login-overview h1 {
-  margin-top: 0;
-  font-size: 32px;
-  margin-bottom: 16px;
-}
-
-.login-overview p {
-  line-height: 1.7;
-  margin-bottom: 16px;
-  color: rgba(226, 232, 240, 0.92);
-}
-
-.login-overview ul {
-  padding-left: 20px;
-  margin-bottom: 16px;
-  color: rgba(226, 232, 240, 0.92);
-}
-
-.login-overview li {
-  margin-bottom: 10px;
-}
-
-.login-overview strong {
-  color: #38bdf8;
+  display: flex;
+  justify-content: center;
+  padding: 48px 16px;
 }
 
 .login-card {
-  background-color: rgba(15, 23, 42, 0.92);
-  padding: 44px 40px;
-  border-radius: 24px;
-  width: min(440px, 100%);
+  background-color: #ffffff;
+  padding: 48px 44px;
+  border-radius: 26px;
+  width: min(430px, 100%);
   margin: 0 auto;
-  box-shadow: 0 30px 60px rgba(2, 6, 23, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.08);
+  border: 1px solid #ecf1ff;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
 }
 
 .login-card header {
-  margin-bottom: 24px;
+  margin-bottom: 12px;
 }
 
 .login-card h2 {
-  margin: 0 0 8px;
-  font-size: 28px;
+  margin: 0 0 6px;
+  font-size: 30px;
+  font-weight: 700;
+  color: #111827;
 }
 
 .login-card p {
   margin: 0;
-  color: rgba(226, 232, 240, 0.8);
+  color: #4b5563;
+  font-size: 0.98rem;
 }
+
 
 .form-group {
   display: flex;
   flex-direction: column;
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 
 .form-group label {
   margin-bottom: 8px;
   font-weight: 600;
+  color: #1f2937;
 }
 
 .form-group input {
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background-color: rgba(15, 23, 42, 0.7);
-  color: #e2e8f0;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1.5px solid #d6dcf5;
+  background-color: #f9fbff;
+  color: #111827;
+  font-size: 0.98rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.form-group input::placeholder {
+  color: #9aa5c0;
 }
 
 .form-group input:focus {
-  outline: 2px solid #38bdf8;
+  outline: none;
+  border-color: #2563eb;
+  background-color: #ffffff;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
 }
+
 
 .form-options {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 }
 
 .checkbox {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.checkbox input {
+  width: 18px;
+  height: 18px;
+  accent-color: #2563eb;
 }
 
 .link {
-  color: #38bdf8;
+  color: #2563eb;
   text-decoration: none;
+  font-weight: 600;
 }
 
 .link:hover {
@@ -125,25 +114,28 @@ body {
 }
 
 .link:focus {
-  outline: 2px solid rgba(56, 189, 248, 0.6);
-  outline-offset: 2px;
+  outline: 2px solid rgba(37, 99, 235, 0.2);
+  outline-offset: 3px;
+  border-radius: 4px;
 }
+
 
 .primary-button {
   width: 100%;
   padding: 14px;
-  border-radius: 12px;
-  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  border-radius: 14px;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
   border: none;
-  color: #0f172a;
+  color: #ffffff;
   font-weight: 700;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 18px 30px rgba(37, 99, 235, 0.25);
 }
 
 .primary-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 25px rgba(14, 165, 233, 0.4);
+  box-shadow: 0 20px 34px rgba(37, 99, 235, 0.35);
 }
 
 .feedback {
@@ -151,25 +143,91 @@ body {
   margin-top: 8px;
   min-height: 18px;
   font-size: 0.85rem;
-  color: #fca5a5;
+  color: #dc2626;
+}
+
+.module-kpi {
+  background-color: #f3f6ff;
+  border-radius: 18px;
+  padding: 22px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border: 1px solid #e0e7ff;
+}
+
+.module-kpi h3 {
+  margin: 0;
+  font-size: 0.88rem;
+  color: #1e293b;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.module-highlight {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+.module-highlight.is-visible {
+  animation: moduleFadeIn 420ms ease forwards;
+}
+
+.module-icon {
+  font-size: 42px;
+  line-height: 1;
+  display: inline-flex;
+}
+
+.module-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.module-label {
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+}
+
+.module-name {
+  font-weight: 700;
+  color: #1d4ed8;
+  font-size: 1.2rem;
+}
+
+.module-description {
+  margin: 0;
+  color: #1f2937;
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+@keyframes moduleFadeIn {
+  0% {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (max-width: 960px) {
   .login-container {
-    padding: 24px;
+    padding: 24px 16px;
   }
 
   .login-card {
     padding: 36px 28px;
-  }
-}
-
-@media (max-width: 600px) {
-  .login-overview {
-    padding: 24px;
-  }
-
-  .login-overview h1 {
-    font-size: 26px;
   }
 }

--- a/modules/auth/js/login.js
+++ b/modules/auth/js/login.js
@@ -13,10 +13,34 @@ let rememberMeInput = null;
 let usernameFeedback = null;
 let passwordFeedback = null;
 let generalFeedback = null;
+let moduleIconElement = null;
+let moduleNameElement = null;
+let moduleDescriptionElement = null;
+let moduleHighlightElement = null;
+let kpiRotationTimer = null;
 let navigationHandler = (relativeTarget) => {
   // Navega utilizando rutas relativas calculadas desde este módulo.
   gotoFromModule(import.meta.url, relativeTarget);
 };
+
+const ACTIVE_MODULES = [
+  {
+    name: "Costos",
+    description: "Controla gastos operativos y financieros en tiempo real.",
+    icon: "💼"
+  },
+  {
+    name: "Estrategias de Ventas",
+    description: "Diseña campañas comerciales con métricas claras y accionables.",
+    icon: "🚀"
+  },
+  {
+    name: "Gestión de Tareas",
+    description: "Organiza pendientes, responsables y fechas límite por proyecto.",
+    icon: "🗒️"
+  }
+];
+const KPI_ROTATION_INTERVAL = 1400;
 
 if (typeof document !== "undefined") {
   loginForm = document.querySelector("#loginForm");
@@ -26,6 +50,10 @@ if (typeof document !== "undefined") {
   usernameFeedback = document.querySelector("#usernameFeedback");
   passwordFeedback = document.querySelector("#passwordFeedback");
   generalFeedback = document.querySelector("#generalFeedback");
+  moduleIconElement = document.querySelector("#moduleIcon");
+  moduleNameElement = document.querySelector("#moduleName");
+  moduleDescriptionElement = document.querySelector("#moduleDescription");
+  moduleHighlightElement = document.querySelector("#moduleHighlight");
 }
 
 // Inicializa la pantalla limpiando cualquier mensaje previo.
@@ -46,6 +74,8 @@ export function initializeForm(feedbackElements = {}) {
   if (generalElement) {
     generalElement.textContent = "";
   }
+
+  startModuleRotation();
 }
 
 // Valida si el username cumple los criterios.
@@ -171,6 +201,53 @@ if (typeof document !== "undefined") {
   }
 }
 
+export function startModuleRotation(
+  modules = ACTIVE_MODULES,
+  elements = {},
+  interval = KPI_ROTATION_INTERVAL
+) {
+  const targetElements = {
+    icon: moduleIconElement,
+    name: moduleNameElement,
+    description: moduleDescriptionElement,
+    container: moduleHighlightElement,
+    ...elements
+  };
+
+  if (!targetElements.name || !targetElements.description || modules.length === 0) {
+    return;
+  }
+
+  let moduleIndex = 0;
+
+  const updateModule = () => {
+    const moduleData = modules[moduleIndex];
+
+    if (targetElements.icon) {
+      targetElements.icon.textContent = moduleData.icon ?? "";
+    }
+
+    targetElements.name.textContent = moduleData.name;
+    targetElements.description.textContent = moduleData.description;
+
+    if (targetElements.container) {
+      targetElements.container.classList.remove("is-visible");
+      void targetElements.container.offsetWidth;
+      targetElements.container.classList.add("is-visible");
+    }
+
+    moduleIndex = (moduleIndex + 1) % modules.length;
+  };
+
+  updateModule();
+
+  if (kpiRotationTimer) {
+    clearInterval(kpiRotationTimer);
+  }
+
+  kpiRotationTimer = setInterval(updateModule, interval);
+}
+
 export default {
   initializeForm,
   validateUsername,
@@ -178,5 +255,6 @@ export default {
   fetchUserByUsername,
   handleLoginSubmit,
   setNavigationHandler,
-  redirectToDashboard
+  redirectToDashboard,
+  startModuleRotation
 };

--- a/modules/auth/login.html
+++ b/modules/auth/login.html
@@ -1,37 +1,14 @@
 <!DOCTYPE html>
 <html lang="es">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Login - Sistema Modular</title>
-    <link rel="stylesheet" href="../../public/css/global.css">
-    <link rel="stylesheet" href="./css/login.css">
+    <link rel="stylesheet" href="../../public/css/global.css" />
+    <link rel="stylesheet" href="./css/login.css" />
   </head>
   <body>
     <main class="login-container">
-      <section class="login-overview">
-        <h1>Bienvenido a tu Portal de Herramientas Empresariales</h1>
-        <p>
-          Este portal reúne en un solo lugar las principales aplicaciones que necesitas
-          para gestionar y hacer crecer tu negocio de manera ágil y profesional.
-        </p>
-        <p>
-          Desde aquí podrás acceder a diferentes módulos diseñados para cubrir áreas clave
-          de tu organización:
-        </p>
-        <ul>
-          <li><strong>CRM:</strong> administra clientes, contactos y oportunidades de venta.</li>
-          <li><strong>Catálogo:</strong> organiza y presenta tu oferta de productos y servicios.</li>
-          <li><strong>Chatbot Web:</strong> brinda atención automática y disponible 24/7.</li>
-          <li><strong>Estrategias de Marketing:</strong> planifica y ejecuta campañas efectivas.</li>
-          <li><strong>Herramientas Extra:</strong> utilidades complementarias para la gestión diaria.</li>
-        </ul>
-        <p>
-          Cada módulo está pensado para integrarse en un sistema sencillo de usar, pero lo
-          suficientemente robusto para ayudarte a tomar decisiones basadas en datos y optimizar
-          tus procesos.
-        </p>
-      </section>
       <section class="login-card">
         <header>
           <h2>Acceso al Sistema</h2>
@@ -40,24 +17,35 @@
         <form id="loginForm" novalidate>
           <div class="form-group">
             <label for="username">Usuario</label>
-            <input type="text" id="username" name="username" placeholder="usuario_profesional" autocomplete="username" required>
+            <input type="text" id="username" name="username" placeholder="usuario_profesional" autocomplete="username" required />
             <span class="feedback" id="usernameFeedback"></span>
           </div>
           <div class="form-group">
             <label for="password">Contraseña</label>
-            <input type="password" id="password" name="password" placeholder="********" autocomplete="current-password" required>
+            <input type="password" id="password" name="password" placeholder="********" autocomplete="current-password" required />
             <span class="feedback" id="passwordFeedback"></span>
           </div>
           <div class="form-options">
             <label class="checkbox">
-              <input type="checkbox" id="rememberMe" name="rememberMe">
+              <input type="checkbox" id="rememberMe" name="rememberMe" />
               <span>Recordarme</span>
             </label>
-    <a class="link" href="./register.html">Crear cuenta</a>
+            <a class="link" href="./register.html">Crear cuenta</a>
           </div>
           <button type="submit" class="primary-button">Ingresar</button>
           <span class="feedback" id="generalFeedback"></span>
         </form>
+        <section class="module-kpi" aria-live="polite">
+          <h3>Módulos activos</h3>
+          <article class="module-highlight" id="moduleHighlight">
+            <span class="module-icon" id="moduleIcon" aria-hidden="true"></span>
+            <div class="module-copy">
+              <span class="module-label">Mostrando:</span>
+              <span class="module-name" id="moduleName"></span>
+              <p class="module-description" id="moduleDescription"></p>
+            </div>
+          </article>
+        </section>
       </section>
     </main>
     <script type="module" src="../../lib/supabaseClient.js"></script>

--- a/modules/dashboard/css/dashboard-carousel.css
+++ b/modules/dashboard/css/dashboard-carousel.css
@@ -1,0 +1,437 @@
+:root {
+  --card-max: 1080px;
+  --viewport-max: 920px;
+  --gutter: 56px;
+  --edge: 14px;
+}
+
+.tasks-card {
+  position: relative;
+  max-width: var(--card-max);
+  margin: 0 auto;
+  padding: 20px 20px 56px;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #f2efff 0%, #edf0ff 100%);
+  box-shadow: 0 10px 24px rgba(31, 38, 135, 0.12);
+  overflow: hidden;
+  transition: opacity 220ms ease;
+}
+
+.tasks-card[data-ready="false"] {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.tasks-card[data-ready="true"] {
+  opacity: 1;
+  visibility: visible;
+}
+
+.tasks-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.tasks-card__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 520px;
+}
+
+.tasks-card__title {
+  margin: 0;
+  font-size: 1.6rem;
+  line-height: 1.2;
+  color: #1e1b4b;
+}
+
+.tasks-card__subtitle {
+  margin: 0;
+  color: rgba(30, 27, 75, 0.72);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.tasks-card__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #3730a3, #4f46e5);
+  color: #ffffff;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 18px 36px rgba(79, 70, 229, 0.3);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.tasks-card__cta:hover,
+.tasks-card__cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 48px rgba(67, 56, 202, 0.35);
+  background: linear-gradient(135deg, #312e81, #4338ca);
+  outline: none;
+}
+
+.tasks-card__inner {
+  position: relative;
+}
+
+.carousel-viewport {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  max-width: var(--viewport-max);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  box-sizing: border-box;
+  touch-action: pan-y;
+}
+
+.carousel-track {
+  display: flex;
+  transition: transform 360ms ease;
+  will-change: transform;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.carousel-slide {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 16px;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 280ms ease;
+}
+
+.carousel-slide.is-active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.carousel-slide > * {
+  margin: 0;
+}
+
+.carousel-status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 24px;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1e1b4b;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(4px);
+  z-index: 2;
+}
+
+.tasks-card--empty .carousel-viewport {
+  padding-top: 48px;
+  padding-bottom: 48px;
+}
+
+.carousel-status[data-tone="empty"] {
+  flex-direction: column;
+  gap: 12px;
+  text-align: center;
+  color: #312e81;
+  background: linear-gradient(180deg, rgba(99, 102, 241, 0.12), rgba(129, 140, 248, 0.08));
+}
+
+.carousel-status[data-tone="empty"]::before {
+  content: "\2728";
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.carousel-status[data-tone="error"] {
+  color: #b91c1c;
+  background: rgba(248, 113, 113, 0.18);
+}
+
+.carousel-status[data-tone="loading"] {
+  color: #4338ca;
+}
+
+.carousel-status[hidden] {
+  display: none;
+}
+
+.carousel-status[data-mode="announce"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}
+
+.carousel-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 0;
+  background: radial-gradient(109% 109% at 50% 0%, #5a67f2 0%, #4f46e5 100%);
+  color: #ffffff;
+  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.35);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, opacity 0.25s ease;
+  z-index: 3;
+}
+.carousel-btn.prev {
+  left: var(--edge);
+}
+
+.carousel-btn.next {
+  right: var(--edge);
+}
+
+.carousel-btn:hover,
+.carousel-btn:focus-visible {
+  transform: translateY(-50%) translateY(-2px);
+  box-shadow: 0 12px 26px rgba(79, 70, 229, 0.45);
+  outline: none;
+}
+
+.carousel-btn:focus-visible {
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.35), 0 12px 26px rgba(79, 70, 229, 0.45);
+}
+
+.carousel-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+  box-shadow: none;
+  transform: translateY(-50%);
+}
+
+.carousel-indicators {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 18px;
+  width: calc(100% - (var(--gutter) * 2));
+  max-width: calc(var(--viewport-max) - (var(--gutter) * 2));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+}
+
+.tasks-card--status-visible .carousel-indicators {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.carousel-indicators .counter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.12);
+  font: 600 12px/1 system-ui, -apple-system, "Segoe UI", Roboto;
+  color: #4f46e5;
+  box-shadow: 0 6px 18px rgba(79, 70, 229, 0.18);
+  pointer-events: auto;
+}
+
+.task-card {
+  width: 100%;
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 12px 22px rgba(16, 24, 40, 0.08);
+  padding: 22px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  color: #1e1b4b;
+}
+
+.task-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.task-card__title {
+  margin: 0;
+  font-size: 1.6rem;
+  line-height: 1.2;
+}
+
+.task-card__deadline {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(67, 56, 202, 0.9);
+}
+
+.task-card__assignments {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  row-gap: 12px;
+  column-gap: 16px;
+  margin: 0;
+}
+
+.task-card__meta-label {
+  font-size: 0.95rem;
+  color: rgba(30, 27, 75, 0.72);
+}
+
+.task-card__meta-value {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.task-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 18px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  text-transform: capitalize;
+  color: #ffffff;
+  background: #4c1d95;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
+.task-card__badge--priority-baja {
+  background: linear-gradient(135deg, #047857, #22c55e);
+}
+
+.task-card__badge--priority-media {
+  background: linear-gradient(135deg, #b45309, #f59e0b);
+}
+
+.task-card__badge--priority-alta {
+  background: linear-gradient(135deg, #b91c1c, #ef4444);
+}
+
+.task-card__description {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: rgba(30, 27, 75, 0.78);
+}
+
+.task-card__footer {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.task-card__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.task-card__status--pendiente {
+  background: rgba(67, 56, 202, 0.12);
+  color: #4338ca;
+}
+
+.task-card__status--completado {
+  background: rgba(16, 185, 129, 0.16);
+  color: #047857;
+}
+
+.task-card__status--en-progreso {
+  background: rgba(14, 165, 233, 0.16);
+  color: #0369a1;
+}
+
+.task-card__status--cancelado {
+  background: rgba(239, 68, 68, 0.16);
+  color: #b91c1c;
+}
+
+@media (max-width: 1024px) {
+  :root {
+    --viewport-max: 780px;
+    --gutter: 52px;
+  }
+}
+
+@media (max-width: 768px) {
+  :root {
+    --viewport-max: 620px;
+    --gutter: 48px;
+  }
+
+  .tasks-card {
+    padding: 16px 16px 54px;
+  }
+
+  .tasks-card__cta {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .carousel-btn {
+    width: 40px;
+    height: 40px;
+  }
+}
+
+@media (max-width: 480px) {
+  :root {
+    --viewport-max: 420px;
+    --gutter: 44px;
+  }
+
+  .tasks-card {
+    padding: 14px 12px 54px;
+  }
+
+  .carousel-btn {
+    width: 38px;
+    height: 38px;
+  }
+
+  .carousel-slide {
+    padding: 12px;
+  }
+
+  .task-card {
+    padding: 20px;
+  }
+
+  .task-card__assignments {
+    grid-template-columns: 1fr;
+  }
+}

--- a/modules/dashboard/css/dashboard.css
+++ b/modules/dashboard/css/dashboard.css
@@ -1,95 +1,354 @@
 /* dashboard.css
  * Estilos para el Dashboard principal. */
 
+:root {
+  --color-surface: #ffffff;
+  --color-primary: #2563eb;
+  --color-text: #1e293b;
+  --color-muted: #64748b;
+  --color-border: #e2e8f0;
+  --shadow-base: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
 body {
   min-height: 100vh;
-  background: radial-gradient(circle at top left, #1e293b, #0f172a 55%);
+  margin: 0;
+  background: #f8fafc;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 40px 20px;
+  padding: 48px 24px;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--color-text);
+  overflow-x: hidden;
 }
 
 .dashboard-container {
-  width: min(1100px, 100%);
-  background-color: rgba(15, 23, 42, 0.9);
+  width: min(1140px, 100%);
+  background: var(--color-surface);
   border-radius: 24px;
-  padding: 40px;
-  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.6);
+  padding: 48px;
+  box-shadow: var(--shadow-base);
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 40px;
 }
 
 .dashboard-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
+  gap: 24px;
+}
+
+.dashboard-header__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .welcome-label {
   margin: 0;
-  color: rgba(148, 163, 184, 0.8);
+  color: var(--color-muted);
   font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-#usernameDisplay {
-  margin: 4px 0 0;
-  font-size: 1.8rem;
+.dashboard-title {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.dashboard-subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--color-muted);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
 }
 
 .logout-button {
-  background: transparent;
-  border: 1px solid rgba(248, 113, 113, 0.6);
-  color: #fca5a5;
-  padding: 10px 20px;
-  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  background: #f8fafc;
+  color: var(--color-muted);
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
-.logout-button:hover {
-  background: rgba(248, 113, 113, 0.15);
+.logout-button:hover,
+.logout-button:focus-visible {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #ffffff;
+  outline: none;
 }
 
-.modules-grid {
+.dashboard-layout {
   display: grid;
-  gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 32px;
 }
 
-.module-card {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.15), rgba(14, 165, 233, 0.1));
-  border: 1px solid rgba(56, 189, 248, 0.2);
-  border-radius: 18px;
-  padding: 24px;
+.tasks-panel,
+.modules-panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.tasks-panel__header h2,
+.modules-panel__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--color-text);
+}
+
+.tasks-panel__summary,
+.modules-panel__summary {
+  margin: 8px 0 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.tasks-panel__content {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
-.module-card h2 {
+.tasks-panel__status {
   margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
 }
 
-.module-card p {
+.tasks-list {
+  list-style: none;
+  padding: 0;
   margin: 0;
-  color: rgba(226, 232, 240, 0.8);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.module-button {
-  align-self: flex-start;
-  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
-  color: #0f172a;
-  font-weight: 700;
-  border: none;
+.task-card {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 18px 20px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px 16px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+}
+
+.task-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.task-card__due-date {
+  margin: 0;
+  justify-self: end;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.task-card__meta {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.task-card__priority {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: #f8fafc;
+  color: var(--color-text);
+}
+
+.task-card__status {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-primary);
+}
+
+.tasks-panel__link {
+  align-self: flex-end;
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: none;
+  padding: 8px 0;
+  transition: color 0.2s ease;
+}
+
+.tasks-panel__link:hover,
+.tasks-panel__link:focus-visible {
+  color: #1d4ed8;
+  outline: none;
+}
+
+.modules-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.module-card {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: 24px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  gap: 12px 16px;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.06);
+}
+
+.module-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: rgba(37, 99, 235, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  grid-row: span 2;
+}
+
+.module-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.module-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--color-text);
+}
+
+.module-card__description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.module-card__action {
+  grid-column: 1 / -1;
+  justify-self: flex-start;
+  background: var(--color-primary);
+  color: #ffffff;
+  text-decoration: none;
+  padding: 10px 18px;
   border-radius: 12px;
-  padding: 12px 22px;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.module-button:hover {
+.module-card__action:hover,
+.module-card__action:focus-visible {
+  background: #1d4ed8;
   transform: translateY(-1px);
-  box-shadow: 0 15px 30px rgba(56, 189, 248, 0.35);
+  outline: none;
+}
+
+.dashboard-footer {
+  display: flex;
+  justify-content: center;
+}
+
+.dashboard-footer__copy {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1024px) {
+  .dashboard-container {
+    padding: 40px 36px;
+  }
+
+  .dashboard-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 32px 16px;
+  }
+
+  .dashboard-container {
+    padding: 32px 24px;
+    border-radius: 20px;
+  }
+
+  .dashboard-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .header-actions {
+    justify-content: flex-start;
+  }
+
+  .modules-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .task-card {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .task-card__due-date {
+    justify-self: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .dashboard-container {
+    padding: 24px 18px;
+  }
+
+  .module-card {
+    grid-template-columns: 1fr;
+  }
+
+  .module-card__icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+  }
 }

--- a/modules/dashboard/index.html
+++ b/modules/dashboard/index.html
@@ -1,33 +1,69 @@
 <!DOCTYPE html>
 <html lang="es">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard - Sistema Modular</title>
-    <link rel="stylesheet" href="../../public/css/global.css">
-    <link rel="stylesheet" href="./css/dashboard.css">
+    <link rel="stylesheet" href="../../public/css/global.css" />
+    <link rel="stylesheet" href="./css/dashboard.css" />
   </head>
   <body>
     <main class="dashboard-container">
       <header class="dashboard-header">
-        <div>
+        <div class="dashboard-header__copy">
           <p class="welcome-label">Bienvenido de nuevo</p>
-          <h1 id="usernameDisplay">Usuario</h1>
+          <h1 id="usernameDisplay" class="dashboard-title">Usuario</h1>
+          <p class="dashboard-subtitle">Revisa tus tareas clave y accede a los módulos activos.</p>
         </div>
-        <button id="logoutButton" class="logout-button">Cerrar sesión</button>
+        <div class="header-actions">
+          <button id="logoutButton" class="logout-button" type="button">Cerrar sesión</button>
+        </div>
       </header>
-      <section class="modules-grid">
-        <a class="module-card" href="../costos/index.html" data-module="costos">
-          <h2>Costos</h2>
-          <p>Administra y monitorea la estructura de costos de tu operación.</p>
-          <span class="module-button">Ir a Costos</span>
-        </a>
-        <a class="module-card" href="../estrategias/index.html" data-module="estrategias">
-          <h2>Estrategias de Ventas</h2>
-          <p>Diseña campañas y planes de marketing para impulsar tu crecimiento.</p>
-          <span class="module-button">Ir a Estrategias</span>
-        </a>
-      </section>
+
+      <div class="dashboard-layout">
+        <section class="tasks-panel" aria-labelledby="tasksPanelTitle">
+          <header class="tasks-panel__header">
+            <div>
+              <h2 id="tasksPanelTitle">Tareas asignadas</h2>
+              <p class="tasks-panel__summary">Mantén el foco en tus prioridades inmediatas.</p>
+            </div>
+          </header>
+          <div class="tasks-panel__content">
+            <p id="tasksStatus" class="tasks-panel__status" role="status">Cargando tus tareas...</p>
+            <ul class="tasks-list" id="tasksList" aria-live="polite"></ul>
+          </div>
+          <a class="tasks-panel__link" id="tasksViewAllButton" href="../tareas/index.html">Ver todas las tareas</a>
+        </section>
+
+        <section class="modules-panel" aria-labelledby="modulesPanelTitle">
+          <header class="modules-panel__header">
+            <h2 id="modulesPanelTitle">Módulos activos</h2>
+            <p class="modules-panel__summary">Accede rápidamente a tus herramientas clave.</p>
+          </header>
+          <div class="modules-grid">
+            <article class="module-card" data-module="costos">
+              <span class="module-card__icon" aria-hidden="true">💰</span>
+              <div class="module-card__body">
+                <h3 class="module-card__title">Costos</h3>
+                <p class="module-card__description">Registra y analiza tus costos fijos y variables.</p>
+              </div>
+              <a class="module-card__action" data-module-link href="../costos/index.html">Ir al módulo</a>
+            </article>
+            <article class="module-card" data-module="estrategias">
+              <span class="module-card__icon" aria-hidden="true">📊</span>
+              <div class="module-card__body">
+                <h3 class="module-card__title">Estrategias de Ventas</h3>
+                <p class="module-card__description">Planifica campañas y haz seguimiento a resultados.</p>
+              </div>
+              <a class="module-card__action" data-module-link href="../estrategias/index.html">Ir al módulo</a>
+            </article>
+          </div>
+        </section>
+      </div>
+
+      <footer class="dashboard-footer">
+        <p class="dashboard-footer__copy">Portal modular para la gestión de tu negocio.</p>
+      </footer>
     </main>
     <script type="module" src="../../lib/supabaseClient.js"></script>
     <script type="module" src="../../lib/authGuard.js"></script>

--- a/modules/dashboard/js/dashboard-carousel.js
+++ b/modules/dashboard/js/dashboard-carousel.js
@@ -1,0 +1,591 @@
+// dashboard-carousel.js
+// Gestiona el carrusel de tareas del dashboard con un layout de tarjeta centrada.
+
+const TRANSITION_DURATION = 360;
+const SWIPE_THRESHOLD_PX = 40;
+
+const PRIORITY_CLASS_MAP = {
+  baja: "task-card__badge--priority-baja",
+  media: "task-card__badge--priority-media",
+  alta: "task-card__badge--priority-alta"
+};
+
+const STATUS_CLASS_MAP = {
+  pendiente: "task-card__status--pendiente",
+  completado: "task-card__status--completado",
+  "en-progreso": "task-card__status--en-progreso",
+  progreso: "task-card__status--en-progreso",
+  cancelado: "task-card__status--cancelado"
+};
+
+// Formatea la fecha en el formato solicitado (ej. 28 sept 2025).
+function formatDate(value) {
+  if (!value) {
+    return "Sin fecha";
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toLocaleDateString("es-CR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric"
+  });
+}
+
+// Normaliza la prioridad a una etiqueta legible.
+function formatPriorityLabel(priority) {
+  if (!priority) {
+    return "Media";
+  }
+
+  const normalized = String(priority).trim().toLowerCase();
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+// Determina la clase CSS adecuada para el badge de prioridad.
+function resolvePriorityClass(priority) {
+  const normalized = String(priority || "").trim().toLowerCase();
+  return PRIORITY_CLASS_MAP[normalized] ?? PRIORITY_CLASS_MAP.media;
+}
+
+// Normaliza el estado de la tarea para mostrarlo como texto.
+function formatStatusLabel(status) {
+  if (!status) {
+    return "Pendiente";
+  }
+
+  const normalized = String(status).replaceAll("_", " ");
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+// Selecciona la clase CSS para el estado de la tarea.
+function resolveStatusClass(status) {
+  const normalized = String(status || "").trim().toLowerCase().replaceAll("_", "-");
+  return STATUS_CLASS_MAP[normalized] ?? STATUS_CLASS_MAP.pendiente;
+}
+
+// Construye el contenido visual de una tarjeta de tarea.
+function createTaskSlide(task, index) {
+  const item = document.createElement("li");
+  item.className = "carousel-slide";
+  item.setAttribute("role", "listitem");
+  item.dataset.index = String(index);
+
+  const card = document.createElement("article");
+  card.className = "task-card";
+
+  const header = document.createElement("header");
+  header.className = "task-card__header";
+
+  const title = document.createElement("h3");
+  title.className = "task-card__title";
+  title.textContent = task.title || "Tarea sin título";
+
+  const deadline = document.createElement("p");
+  deadline.className = "task-card__deadline";
+  deadline.textContent = formatDate(task.due_date);
+
+  header.append(title, deadline);
+
+  const assignments = document.createElement("dl");
+  assignments.className = "task-card__assignments";
+
+  const ownerTitle = document.createElement("dt");
+  ownerTitle.className = "task-card__meta-label";
+  ownerTitle.textContent = "Asignado a";
+
+  const ownerValue = document.createElement("dd");
+  ownerValue.className = "task-card__meta-value";
+  ownerValue.textContent = task.owner || "Sin responsable";
+
+  const priorityTitle = document.createElement("dt");
+  priorityTitle.className = "task-card__meta-label";
+  priorityTitle.textContent = "Prioridad";
+
+  const priorityValue = document.createElement("dd");
+  priorityValue.className = `task-card__badge ${resolvePriorityClass(task.priority)}`;
+  priorityValue.textContent = formatPriorityLabel(task.priority);
+
+  assignments.append(ownerTitle, ownerValue, priorityTitle, priorityValue);
+
+  const description = document.createElement("p");
+  description.className = "task-card__description";
+  description.textContent = task.description || "Sin descripción disponible.";
+
+  const footer = document.createElement("footer");
+  footer.className = "task-card__footer";
+
+  const status = document.createElement("span");
+  status.className = `task-card__status ${resolveStatusClass(task.status)}`;
+  status.textContent = formatStatusLabel(task.status);
+
+  footer.appendChild(status);
+
+  card.append(header, assignments, description, footer);
+  item.appendChild(card);
+
+  return item;
+}
+
+// Inicializa y devuelve la API pública del carrusel de tareas.
+export function initTasksCarousel({ containerSelector } = {}) {
+  const root =
+    typeof containerSelector === "string"
+      ? document.querySelector(containerSelector)
+      : containerSelector;
+
+  if (!root) {
+    return null;
+  }
+
+  const viewport = root.querySelector(".carousel-viewport");
+  const track = root.querySelector(".carousel-track");
+  const prevBtn = root.querySelector(".carousel-btn.prev");
+  const nextBtn = root.querySelector(".carousel-btn.next");
+  const indicators = root.querySelector(".carousel-indicators");
+  const counterEl = indicators?.querySelector(".counter .current") ?? null;
+  const totalEl = indicators?.querySelector(".counter .total") ?? null;
+  const status = root.querySelector(".carousel-status");
+
+  let slides = [];
+  let index = 0;
+  let slideWidth = 0;
+  let activePointerId = null;
+  let startX = 0;
+  let isDragging = false;
+
+  function parsePxValue(raw) {
+    return Number.parseFloat(raw) || 0;
+  }
+
+  function varPx(name) {
+    const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    return Number.parseInt(value, 10) || 0;
+  }
+
+  function clamp(value, min, max) {
+    if (max < min) {
+      return min;
+    }
+
+    return Math.min(Math.max(value, min), max);
+  }
+
+  // 1) Layout: fija width exacto por slide y ancho del track.
+  function layout() {
+    if (!viewport || !track) {
+      return;
+    }
+
+    const computed = getComputedStyle(viewport);
+    const paddingLeft = parsePxValue(computed.paddingLeft);
+    const paddingRight = parsePxValue(computed.paddingRight);
+    const availableWidth = Math.max(0, viewport.clientWidth - paddingLeft - paddingRight);
+
+    slideWidth = Math.max(1, Math.round(availableWidth));
+
+    slides.forEach((li) => {
+      li.style.width = `${slideWidth}px`;
+    });
+
+    if (slides.length) {
+      track.style.width = `${slideWidth * slides.length}px`;
+    } else {
+      track.style.width = "0px";
+    }
+
+    applyTransform(false);
+    positionArrows(paddingLeft, paddingRight);
+  }
+
+  // 2) Posiciona flechas pegadas al borde interno del viewport (no del card).
+  function positionArrows(paddingLeftOverride, paddingRightOverride) {
+    if (!viewport || !prevBtn || !nextBtn) {
+      return;
+    }
+
+    const vpRect = viewport.getBoundingClientRect();
+    const rootRect = root.getBoundingClientRect();
+    const paddingLeft =
+      typeof paddingLeftOverride === "number"
+        ? paddingLeftOverride
+        : parsePxValue(getComputedStyle(viewport).paddingLeft);
+    const paddingRight =
+      typeof paddingRightOverride === "number"
+        ? paddingRightOverride
+        : parsePxValue(getComputedStyle(viewport).paddingRight);
+    const edge = varPx("--edge");
+    const minGap = 12;
+
+    if (prevBtn) {
+      const buttonWidth = prevBtn.offsetWidth || 0;
+      const marginStart = vpRect.left - rootRect.left;
+      const contentStart = marginStart + paddingLeft;
+      const maxLeft = contentStart - buttonWidth - minGap;
+      const minLeftBase = Math.max(0, marginStart);
+      const minLeft = maxLeft > edge ? Math.max(minLeftBase, edge) : minLeftBase;
+      const available = Math.max(0, paddingLeft - buttonWidth);
+      const natural = marginStart + available / 2;
+      const safeMax = Math.max(minLeft, maxLeft);
+      const finalLeft = clamp(natural, minLeft, safeMax);
+
+      prevBtn.style.left = `${Math.max(0, finalLeft)}px`;
+      prevBtn.style.right = "auto";
+    }
+
+    if (nextBtn) {
+      const buttonWidth = nextBtn.offsetWidth || 0;
+      const marginEnd = rootRect.right - vpRect.right;
+      const contentEndFromRight = marginEnd + paddingRight;
+      const maxRight = contentEndFromRight - buttonWidth - minGap;
+      const minRightBase = Math.max(0, marginEnd);
+      const minRight = maxRight > edge ? Math.max(minRightBase, edge) : minRightBase;
+      const available = Math.max(0, paddingRight - buttonWidth);
+      const natural = marginEnd + available / 2;
+      const safeMax = Math.max(minRight, maxRight);
+      const finalRight = clamp(natural, minRight, safeMax);
+
+      nextBtn.style.right = `${Math.max(0, finalRight)}px`;
+      nextBtn.style.left = "auto";
+    }
+  }
+
+  // 3) Movimiento.
+  function applyTransform(animate = true) {
+    if (!track) {
+      return;
+    }
+
+    if (!slides.length) {
+      if (!animate) {
+        track.style.transition = "none";
+        track.style.transform = "translateX(0px)";
+        void track.offsetHeight;
+        track.style.transition = `transform ${TRANSITION_DURATION}ms ease`;
+      } else {
+        track.style.transform = "translateX(0px)";
+      }
+
+      updateUI();
+      return;
+    }
+
+    const offset = -Math.round(index * slideWidth);
+
+    if (!animate) {
+      track.style.transition = "none";
+    }
+
+    track.style.transform = `translateX(${offset}px)`;
+
+    if (!animate) {
+      void track.offsetHeight;
+      track.style.transition = `transform ${TRANSITION_DURATION}ms ease`;
+    }
+
+    updateUI();
+  }
+
+  function goTo(targetIndex, animate = true) {
+    if (!slides.length) {
+      updateUI();
+      return;
+    }
+
+    const clamped = Math.max(0, Math.min(targetIndex, slides.length - 1));
+
+    if (clamped === index && animate) {
+      updateUI();
+      return;
+    }
+
+    index = clamped;
+    applyTransform(animate);
+  }
+
+  function next() {
+    goTo(index + 1, true);
+  }
+
+  function prev() {
+    goTo(index - 1, true);
+  }
+
+  // 4) UI.
+  function updateUI() {
+    const total = slides.length;
+
+    if (prevBtn) {
+      prevBtn.disabled = total <= 1 || index === 0;
+    }
+
+    if (nextBtn) {
+      nextBtn.disabled = total <= 1 || index === total - 1;
+    }
+
+    if (counterEl) {
+      counterEl.textContent = total ? String(index + 1) : "0";
+    }
+
+    if (totalEl) {
+      totalEl.textContent = String(total);
+    }
+
+    slides.forEach((slide, slideIndex) => {
+      const isActive = slideIndex === index;
+      slide.classList.toggle("is-active", isActive);
+      slide.setAttribute("aria-hidden", isActive ? "false" : "true");
+    });
+  }
+
+  function handlePointerDown(event) {
+    if (!viewport || !slides.length) {
+      return;
+    }
+
+    if (event.pointerType === "mouse" && event.button !== 0) {
+      return;
+    }
+
+    if (slides.length <= 1) {
+      return;
+    }
+
+    activePointerId = event.pointerId;
+    startX = event.clientX;
+    isDragging = true;
+
+    if (track) {
+      track.style.transition = "none";
+    }
+
+    viewport.setPointerCapture(event.pointerId);
+  }
+
+  function handlePointerMove(event) {
+    if (!isDragging || activePointerId !== event.pointerId || !track) {
+      return;
+    }
+
+    const deltaX = event.clientX - startX;
+    const base = -Math.round(index * slideWidth);
+    track.style.transform = `translateX(${base + deltaX}px)`;
+  }
+
+  function handlePointerEnd(event) {
+    if (!viewport || activePointerId !== event.pointerId) {
+      return;
+    }
+
+    const deltaX = event.clientX - startX;
+    const movedEnough = Math.abs(deltaX) >= SWIPE_THRESHOLD_PX;
+
+    if (viewport.hasPointerCapture(event.pointerId)) {
+      viewport.releasePointerCapture(event.pointerId);
+    }
+
+    if (track) {
+      track.style.transition = `transform ${TRANSITION_DURATION}ms ease`;
+    }
+
+    isDragging = false;
+    activePointerId = null;
+
+    if (movedEnough) {
+      if (deltaX < 0) {
+        next();
+      } else {
+        prev();
+      }
+    } else {
+      applyTransform(true);
+    }
+  }
+
+  function handlePointerCancel(event) {
+    if (!viewport || activePointerId !== event.pointerId) {
+      return;
+    }
+
+    if (viewport.hasPointerCapture(event.pointerId)) {
+      viewport.releasePointerCapture(event.pointerId);
+    }
+
+    if (track) {
+      track.style.transition = `transform ${TRANSITION_DURATION}ms ease`;
+    }
+
+    isDragging = false;
+    activePointerId = null;
+    applyTransform(true);
+  }
+
+  function handleKeyDown(event) {
+    if (!slides.length) {
+      return;
+    }
+
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      next();
+    } else if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      prev();
+    }
+  }
+
+  window.addEventListener(
+    "resize",
+    () => {
+      layout();
+    },
+    { passive: true }
+  );
+
+  if (prevBtn) {
+    prevBtn.addEventListener("click", () => {
+      prev();
+    });
+  }
+
+  if (nextBtn) {
+    nextBtn.addEventListener("click", () => {
+      next();
+    });
+  }
+
+  if (viewport) {
+    viewport.addEventListener("keydown", handleKeyDown, { passive: true });
+    viewport.addEventListener("pointerdown", handlePointerDown);
+    viewport.addEventListener("pointermove", handlePointerMove);
+    viewport.addEventListener("pointerup", handlePointerEnd);
+    viewport.addEventListener("pointercancel", handlePointerCancel);
+  }
+
+  requestAnimationFrame(() => {
+    root.dataset.ready = "true";
+  });
+
+  // Expone la API necesaria para que dashboard.js gestione los datos.
+  return {
+    showLoading(message = "Cargando tus tareas...") {
+      if (status) {
+        status.textContent = message;
+        status.dataset.mode = "message";
+        status.dataset.tone = "loading";
+        status.hidden = false;
+      }
+
+      if (root) {
+        root.classList.remove("tasks-card--empty");
+        root.classList.add("tasks-card--status-visible");
+      }
+
+      if (counterEl) {
+        counterEl.textContent = "0";
+      }
+
+      if (totalEl) {
+        totalEl.textContent = "0";
+      }
+
+      if (prevBtn) {
+        prevBtn.disabled = true;
+      }
+
+      if (nextBtn) {
+        nextBtn.disabled = true;
+      }
+
+      positionArrows();
+    },
+    showMessage(message, options = {}) {
+      const { tone = "info" } = options;
+
+      if (status) {
+        status.textContent = message;
+        status.dataset.mode = "message";
+        status.dataset.tone = tone;
+        status.hidden = false;
+      }
+
+      slides = [];
+      index = 0;
+
+      if (track) {
+        track.innerHTML = "";
+        track.style.width = "0px";
+        track.style.transform = "translateX(0px)";
+      }
+
+      if (counterEl) {
+        counterEl.textContent = "0";
+      }
+
+      if (totalEl) {
+        totalEl.textContent = "0";
+      }
+
+      if (prevBtn) {
+        prevBtn.disabled = true;
+      }
+
+      if (nextBtn) {
+        nextBtn.disabled = true;
+      }
+
+      if (root) {
+        root.classList.toggle("tasks-card--empty", tone === "empty");
+        root.classList.add("tasks-card--status-visible");
+      }
+
+      positionArrows();
+    },
+    setSlides(tasks) {
+      if (!track) {
+        return;
+      }
+
+      track.innerHTML = "";
+      slides = [];
+      index = 0;
+
+      if (!Array.isArray(tasks) || !tasks.length) {
+        this.showMessage("¡No olvides agendar tus tareas para estar al día!", { tone: "empty" });
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+
+      tasks.forEach((task, taskIndex) => {
+        fragment.appendChild(createTaskSlide(task, taskIndex));
+      });
+
+      track.appendChild(fragment);
+      slides = Array.from(track.children);
+
+      if (status) {
+        status.dataset.mode = "announce";
+        status.dataset.tone = "info";
+        status.hidden = true;
+      }
+
+      if (root) {
+        root.classList.remove("tasks-card--empty");
+        root.classList.remove("tasks-card--status-visible");
+      }
+
+      if (totalEl) {
+        totalEl.textContent = String(slides.length);
+      }
+
+      layout();
+      goTo(0, false);
+    }
+  };
+}

--- a/modules/dashboard/js/dashboard.js
+++ b/modules/dashboard/js/dashboard.js
@@ -1,40 +1,64 @@
 // dashboard.js
 // Administra la vista principal tras un inicio de sesión válido.
 
-import { requireAuth, getCurrentUsername, logout } from "../../../lib/authGuard.js";
+import {
+  requireAuth,
+  getCurrentUsername,
+  logout,
+  resolveCurrentUserId
+} from "../../../lib/authGuard.js";
+import { supabaseClient } from "../../../lib/supabaseClient.js";
 
 const usernameDisplay = document.querySelector("#usernameDisplay");
 const logoutButton = document.querySelector("#logoutButton");
 const moduleCards = document.querySelectorAll(".module-card");
+const tasksList = document.querySelector("#tasksList");
+const tasksStatus = document.querySelector("#tasksStatus");
+const tasksViewAllButton = document.querySelector("#tasksViewAllButton");
 
-// Carga la información del usuario autenticado en el encabezado.
+const PRIORITY_ICON_MAP = {
+  alta: { icon: "🔴", label: "Alta" },
+  media: { icon: "🟡", label: "Media" },
+  baja: { icon: "🟢", label: "Baja" }
+};
+
+const STATUS_LABEL_MAP = {
+  pendiente: "Pendiente",
+  completado: "Completado",
+  "en-progreso": "En progreso"
+};
+
+// Obtiene y coloca el nombre del usuario autenticado en la cabecera.
 function loadUsername() {
   const username = getCurrentUsername();
 
+  if (!usernameDisplay) {
+    return;
+  }
+
   if (username) {
-    usernameDisplay.textContent = username;
+    usernameDisplay.textContent = username; // Muestra el nombre real si existe.
   } else {
-    usernameDisplay.textContent = "Usuario";
+    usernameDisplay.textContent = "Usuario"; // Valor por defecto cuando no hay nombre.
   }
 }
 
-// Configura los listeners necesarios para la pantalla.
-function registerEventListeners() {
-  if (logoutButton) {
-    logoutButton.addEventListener("click", () => {
-      logout();
-    });
-  }
-
+// Renderiza los módulos accesibles del dashboard con sus enlaces definitivos.
+function configureModuleCards() {
   moduleCards.forEach((card) => {
-    // Se asegura que cada tarjeta mantenga un href correcto y sea navegable.
+    const actionLink = card.querySelector("[data-module-link]");
+
     switch (card.dataset.module) {
       case "costos": {
-        card.setAttribute("href", "../costos/index.html");
+        if (actionLink) {
+          actionLink.setAttribute("href", "../costos/index.html");
+        }
         break;
       }
       case "estrategias": {
-        card.setAttribute("href", "../estrategias/index.html");
+        if (actionLink) {
+          actionLink.setAttribute("href", "../estrategias/index.html");
+        }
         break;
       }
       default: {
@@ -44,6 +68,153 @@ function registerEventListeners() {
   });
 }
 
+// Formatea la fecha en un formato legible.
+function formatDate(value) {
+  if (!value) {
+    return "Sin fecha";
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toLocaleDateString("es-CR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric"
+  });
+}
+
+function normalizePriority(priority) {
+  const key = String(priority || "media").toLowerCase().trim();
+  return PRIORITY_ICON_MAP[key] ? key : "media";
+}
+
+function normalizeStatus(status) {
+  const key = String(status || "pendiente").toLowerCase().trim().replaceAll("_", "-");
+  return STATUS_LABEL_MAP[key] ? key : "pendiente";
+}
+
+function showTasksStatus(message) {
+  if (tasksStatus) {
+    tasksStatus.textContent = message;
+    tasksStatus.hidden = false;
+  }
+
+  if (tasksList) {
+    tasksList.innerHTML = "";
+  }
+}
+
+function hideTasksStatus() {
+  if (tasksStatus) {
+    tasksStatus.hidden = true;
+  }
+}
+
+function renderTaskItem(task) {
+  const priorityKey = normalizePriority(task.priority);
+  const statusKey = normalizeStatus(task.status);
+
+  const item = document.createElement("li");
+  item.className = "task-card";
+
+  const title = document.createElement("h3");
+  title.className = "task-card__title";
+  title.textContent = task.title || "Tarea sin título";
+
+  const dueDate = document.createElement("p");
+  dueDate.className = "task-card__due-date";
+  dueDate.textContent = formatDate(task.due_date);
+
+  const meta = document.createElement("div");
+  meta.className = "task-card__meta";
+
+  const priority = document.createElement("span");
+  priority.className = "task-card__priority";
+  const priorityInfo = PRIORITY_ICON_MAP[priorityKey];
+  priority.textContent = `${priorityInfo.icon} ${priorityInfo.label}`;
+
+  const status = document.createElement("span");
+  status.className = "task-card__status";
+  status.textContent = STATUS_LABEL_MAP[statusKey];
+
+  meta.append(priority, status);
+
+  item.append(title, dueDate, meta);
+
+  return item;
+}
+
+function renderTasksList(tasks) {
+  if (!tasksList) {
+    return;
+  }
+
+  const visibleTasks = Array.isArray(tasks) ? tasks.slice(0, 2) : [];
+
+  if (visibleTasks.length === 0) {
+    showTasksStatus("No tienes tareas asignadas por ahora.");
+    return;
+  }
+
+  hideTasksStatus();
+
+  tasksList.innerHTML = "";
+
+  const fragment = document.createDocumentFragment();
+  visibleTasks.forEach((task) => {
+    fragment.appendChild(renderTaskItem(task));
+  });
+
+  tasksList.appendChild(fragment);
+}
+
+// Solicita las tareas al backend y las muestra en la lista.
+async function loadDashboardTasks() {
+  showTasksStatus("Cargando tus tareas...");
+
+  const userId = await resolveCurrentUserId();
+
+  if (!userId) {
+    showTasksStatus("No se pudo obtener tu información de usuario.");
+    return;
+  }
+
+  try {
+    const { data, error } = await supabaseClient
+      .from("tareas")
+      .select("id, title, priority, status, due_date")
+      .eq("user_id", userId)
+      .order("due_date", { ascending: true });
+
+    if (error) {
+      throw error;
+    }
+
+    renderTasksList(data ?? []);
+  } catch (error) {
+    console.error("Error al cargar las tareas del dashboard", error);
+    showTasksStatus("No fue posible cargar tus tareas.");
+  }
+}
+
+function registerEventListeners() {
+  if (logoutButton) {
+    logoutButton.addEventListener("click", () => {
+      logout();
+    });
+  }
+
+  if (tasksViewAllButton) {
+    tasksViewAllButton.setAttribute("href", "../tareas/index.html");
+  }
+}
+
 requireAuth();
 loadUsername();
+configureModuleCards();
 registerEventListeners();
+loadDashboardTasks();

--- a/modules/tareas/css/tasks.css
+++ b/modules/tareas/css/tasks.css
@@ -1,0 +1,348 @@
+/* tasks.css
+ * Estilos para el módulo de gestión de tareas.
+ */
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background: #f1f5f9;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #0f172a;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 48px 20px;
+}
+
+.tasks-app {
+  width: min(1120px, 100%);
+  background: #ffffff;
+  border-radius: 28px;
+  padding: 40px;
+  box-shadow: 0 35px 70px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.tasks-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.tasks-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.tasks-breadcrumb {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.tasks-subtitle {
+  margin-top: 8px;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.tasks-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: 10px;
+  border: 1px solid #cbd5f5;
+  text-decoration: none;
+  color: #4338ca;
+  font-weight: 600;
+  background: linear-gradient(135deg, rgba(165, 180, 252, 0.22), rgba(224, 231, 255, 0.6));
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tasks-back:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 30px rgba(99, 102, 241, 0.25);
+}
+
+.tasks-logout {
+  background: transparent;
+  border: 1px solid #cbd5f5;
+  color: #1e293b;
+  border-radius: 12px;
+  padding: 10px 22px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.tasks-logout:hover {
+  background: #1e293b;
+  color: #ffffff;
+}
+
+.tasks-form-card,
+.tasks-list-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 22px;
+  padding: 28px 32px;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.tasks-form-card__header,
+.tasks-list-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tasks-form-card__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.tasks-refresh {
+  border: none;
+  background: #1d4ed8;
+  color: #ffffff;
+  border-radius: 12px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tasks-refresh:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(29, 78, 216, 0.25);
+}
+
+.tasks-form__grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.tasks-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.tasks-field input,
+.tasks-field select,
+.tasks-field textarea {
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+  font-family: inherit;
+}
+
+.tasks-field input:focus,
+.tasks-field select:focus,
+.tasks-field textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.tasks-form__actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.tasks-primary {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+  color: #ffffff;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 24px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tasks-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.35);
+}
+
+.tasks-secondary {
+  background: transparent;
+  color: #1e293b;
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 12px 24px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.tasks-secondary:hover {
+  background: #1e293b;
+  color: #ffffff;
+}
+
+.tasks-secondary--hidden {
+  display: none;
+}
+
+.tasks-feedback {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.tasks-feedback--success {
+  color: #047857;
+}
+
+.tasks-feedback--error {
+  color: #b91c1c;
+}
+
+.tasks-list {
+  display: grid;
+  gap: 16px;
+}
+
+.tasks-list__item {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 18px;
+  padding: 18px 22px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+}
+
+.tasks-list__main {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tasks-list__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.tasks-list__description {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.tasks-list__meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.tasks-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.tasks-badge--status {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.tasks-badge--priority {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.tasks-list__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.tasks-action {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tasks-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.16);
+}
+
+.tasks-action--edit {
+  background: #1d4ed8;
+  color: #ffffff;
+}
+
+.tasks-action--delete {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+@media (max-width: 900px) {
+  body {
+    padding: 32px 16px;
+  }
+
+  .tasks-app {
+    padding: 28px;
+  }
+
+  .tasks-form-card,
+  .tasks-list-card {
+    padding: 24px;
+  }
+
+  .tasks-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 540px) {
+  .tasks-form__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tasks-list__item {
+    grid-template-columns: 1fr;
+  }
+
+  .tasks-list__actions {
+    flex-direction: row;
+  }
+}

--- a/modules/tareas/index.html
+++ b/modules/tareas/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gestión de Tareas - Sistema Modular</title>
+    <link rel="stylesheet" href="../../public/css/global.css" />
+    <link rel="stylesheet" href="./css/tasks.css" />
+  </head>
+  <body>
+    <main class="tasks-app" id="tasksApp">
+      <header class="tasks-header">
+        <div>
+          <p class="tasks-breadcrumb">Módulos</p>
+          <h1>Gestión de Tareas</h1>
+          <p class="tasks-subtitle">
+            Coordina responsables, prioriza pendientes y registra avances en tiempo real.
+          </p>
+        </div>
+        <div class="tasks-header__actions">
+          <a class="tasks-back" href="../dashboard/index.html">← Volver al dashboard</a>
+          <button class="tasks-logout" id="logoutButton" type="button">Cerrar sesión</button>
+        </div>
+      </header>
+
+      <section class="tasks-form-card">
+        <div class="tasks-form-card__header">
+          <div>
+            <p class="tasks-form-card__eyebrow">Nueva tarea</p>
+            <h2 id="formTitle">Registrar tarea</h2>
+          </div>
+          <button class="tasks-refresh" id="refreshButton" type="button">🔄 Refrescar</button>
+        </div>
+
+        <form id="taskForm" novalidate>
+          <div class="tasks-form__grid">
+            <label class="tasks-field">
+              <span>Título</span>
+              <input type="text" id="taskTitle" name="title" placeholder="Ej: Llamar a proveedor" required />
+            </label>
+            <label class="tasks-field">
+              <span>Responsable</span>
+              <input type="text" id="taskOwner" name="owner" placeholder="Ej: Ana Martínez" required />
+            </label>
+            <label class="tasks-field">
+              <span>Fecha límite</span>
+              <input type="date" id="taskDueDate" name="dueDate" required />
+            </label>
+            <label class="tasks-field">
+              <span>Prioridad</span>
+              <select id="taskPriority" name="priority">
+                <option value="alta">Alta</option>
+                <option value="media" selected>Media</option>
+                <option value="baja">Baja</option>
+              </select>
+            </label>
+            <label class="tasks-field">
+              <span>Estado</span>
+              <select id="taskStatus" name="status">
+                <option value="pendiente" selected>Pendiente</option>
+                <option value="en progreso">En progreso</option>
+                <option value="completada">Completada</option>
+              </select>
+            </label>
+          </div>
+          <label class="tasks-field">
+            <span>Descripción</span>
+            <textarea
+              id="taskDescription"
+              name="description"
+              placeholder="Añade detalles, acuerdos o próximos pasos"
+              rows="3"
+            ></textarea>
+          </label>
+          <div class="tasks-form__actions">
+            <button class="tasks-primary" type="submit" id="submitButton">Guardar tarea</button>
+            <button class="tasks-secondary tasks-secondary--hidden" type="button" id="cancelEditButton">
+              Cancelar edición
+            </button>
+          </div>
+        </form>
+        <p class="tasks-feedback" id="formFeedback"></p>
+      </section>
+
+      <section class="tasks-list-card">
+        <header class="tasks-list-card__header">
+          <div>
+            <p class="tasks-form-card__eyebrow">Seguimiento</p>
+            <h2>Tareas registradas</h2>
+          </div>
+        </header>
+        <p class="tasks-feedback" id="listFeedback">Aún no has registrado tareas.</p>
+        <div class="tasks-list" id="tasksList"></div>
+      </section>
+    </main>
+
+    <script type="module" src="../../lib/supabaseClient.js"></script>
+    <script type="module" src="../../lib/authGuard.js"></script>
+    <script type="module" src="./js/tasks.js"></script>
+  </body>
+</html>

--- a/modules/tareas/js/tasks.js
+++ b/modules/tareas/js/tasks.js
@@ -1,0 +1,456 @@
+// tasks.js
+// Controla las operaciones de lectura y escritura del módulo de tareas.
+
+import {
+  requireAuth,
+  logout,
+  resolveCurrentUserId
+} from "../../../lib/authGuard.js";
+import { supabaseClient } from "../../../lib/supabaseClient.js";
+
+const logoutButton = document.querySelector("#logoutButton");
+const refreshButton = document.querySelector("#refreshButton");
+const taskForm = document.querySelector("#taskForm");
+const taskTitleInput = document.querySelector("#taskTitle");
+const taskOwnerInput = document.querySelector("#taskOwner");
+const taskDueDateInput = document.querySelector("#taskDueDate");
+const taskPrioritySelect = document.querySelector("#taskPriority");
+const taskStatusSelect = document.querySelector("#taskStatus");
+const taskDescriptionInput = document.querySelector("#taskDescription");
+const formFeedbackElement = document.querySelector("#formFeedback");
+const listFeedbackElement = document.querySelector("#listFeedback");
+const tasksListElement = document.querySelector("#tasksList");
+const cancelEditButton = document.querySelector("#cancelEditButton");
+const submitButton = document.querySelector("#submitButton");
+const formTitleElement = document.querySelector("#formTitle");
+
+let currentUserId = null;
+let editingTaskId = null;
+let tasksCache = [];
+
+requireAuth();
+
+function setFeedback(element, message, type) {
+  if (!element) {
+    return;
+  }
+
+  element.textContent = message ?? "";
+  element.classList.remove("tasks-feedback--success", "tasks-feedback--error");
+
+  if (!message) {
+    return;
+  }
+
+  if (type === "success") {
+    element.classList.add("tasks-feedback--success");
+  } else if (type === "error") {
+    element.classList.add("tasks-feedback--error");
+  }
+}
+
+function formatDateForInput(value) {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function renderTasks(tasks) {
+  if (!tasksListElement) {
+    return;
+  }
+
+  tasksListElement.innerHTML = "";
+
+  if (!tasks || tasks.length === 0) {
+    setFeedback(listFeedbackElement, "Aún no has registrado tareas.");
+    return;
+  }
+
+  setFeedback(listFeedbackElement, "");
+
+  tasks.forEach((task) => {
+    const card = document.createElement("article");
+    card.className = "tasks-list__item";
+    card.dataset.taskId = String(task.id);
+
+    const mainColumn = document.createElement("div");
+    mainColumn.className = "tasks-list__main";
+
+    const titleElement = document.createElement("h3");
+    titleElement.className = "tasks-list__title";
+    titleElement.textContent = task.title;
+
+    mainColumn.appendChild(titleElement);
+
+    if (task.description) {
+      const descriptionElement = document.createElement("p");
+      descriptionElement.className = "tasks-list__description";
+      descriptionElement.textContent = task.description;
+      mainColumn.appendChild(descriptionElement);
+    }
+
+    const metaRow = document.createElement("div");
+    metaRow.className = "tasks-list__meta";
+    metaRow.innerHTML = `👤 ${task.owner} · 📅 ${new Date(task.due_date).toLocaleDateString("es-CR")}`;
+    mainColumn.appendChild(metaRow);
+
+    const badgesRow = document.createElement("div");
+    badgesRow.className = "tasks-list__meta";
+
+    const statusBadge = document.createElement("span");
+    statusBadge.className = "tasks-badge tasks-badge--status";
+    statusBadge.textContent = `Estado: ${task.status}`;
+
+    const priorityBadge = document.createElement("span");
+    priorityBadge.className = "tasks-badge tasks-badge--priority";
+    priorityBadge.textContent = `Prioridad: ${task.priority}`;
+
+    badgesRow.appendChild(statusBadge);
+    badgesRow.appendChild(priorityBadge);
+
+    mainColumn.appendChild(badgesRow);
+
+    const actionsColumn = document.createElement("div");
+    actionsColumn.className = "tasks-list__actions";
+
+    const editButton = document.createElement("button");
+    editButton.type = "button";
+    editButton.className = "tasks-action tasks-action--edit";
+    editButton.dataset.action = "edit";
+    editButton.dataset.taskId = String(task.id);
+    editButton.textContent = "✏️ Editar";
+
+    const deleteButton = document.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.className = "tasks-action tasks-action--delete";
+    deleteButton.dataset.action = "delete";
+    deleteButton.dataset.taskId = String(task.id);
+    deleteButton.textContent = "🗑️ Eliminar";
+
+    actionsColumn.appendChild(editButton);
+    actionsColumn.appendChild(deleteButton);
+
+    card.appendChild(mainColumn);
+    card.appendChild(actionsColumn);
+
+    tasksListElement.appendChild(card);
+  });
+}
+
+async function logTaskHistory(taskId, action, notes = null) {
+  try {
+    await supabaseClient.from("tareas_historial").insert([
+      {
+        tarea_id: taskId,
+        action,
+        notes
+      }
+    ]);
+  } catch (error) {
+    console.warn("No fue posible registrar el historial de la tarea", error);
+  }
+}
+
+async function fetchTasks() {
+  if (!currentUserId) {
+    return;
+  }
+
+  setFeedback(listFeedbackElement, "Cargando tareas...");
+
+  try {
+    const { data, error } = await supabaseClient
+      .from("tareas")
+      .select("id, title, description, owner, priority, status, due_date, updated_at")
+      .eq("user_id", currentUserId)
+      .order("due_date", { ascending: true });
+
+    if (error) {
+      throw error;
+    }
+
+    tasksCache = data ?? [];
+    renderTasks(tasksCache);
+  } catch (error) {
+    console.error("Error al cargar las tareas", error);
+    setFeedback(listFeedbackElement, "No fue posible cargar las tareas registradas.", "error");
+  }
+}
+
+function resetForm() {
+  if (!taskForm) {
+    return;
+  }
+
+  taskForm.reset();
+  taskPrioritySelect.value = "media";
+  taskStatusSelect.value = "pendiente";
+  editingTaskId = null;
+
+  if (submitButton) {
+    submitButton.textContent = "Guardar tarea";
+  }
+
+  if (formTitleElement) {
+    formTitleElement.textContent = "Registrar tarea";
+  }
+
+  if (cancelEditButton) {
+    cancelEditButton.classList.add("tasks-secondary--hidden");
+  }
+}
+
+function hydrateForm(task) {
+  if (!task) {
+    return;
+  }
+
+  editingTaskId = task.id;
+
+  if (taskTitleInput) {
+    taskTitleInput.value = task.title ?? "";
+  }
+
+  if (taskOwnerInput) {
+    taskOwnerInput.value = task.owner ?? "";
+  }
+
+  if (taskDueDateInput) {
+    taskDueDateInput.value = formatDateForInput(task.due_date);
+  }
+
+  if (taskPrioritySelect) {
+    taskPrioritySelect.value = task.priority ?? "media";
+  }
+
+  if (taskStatusSelect) {
+    taskStatusSelect.value = task.status ?? "pendiente";
+  }
+
+  if (taskDescriptionInput) {
+    taskDescriptionInput.value = task.description ?? "";
+  }
+
+  if (submitButton) {
+    submitButton.textContent = "Actualizar tarea";
+  }
+
+  if (formTitleElement) {
+    formTitleElement.textContent = "Editar tarea";
+  }
+
+  if (cancelEditButton) {
+    cancelEditButton.classList.remove("tasks-secondary--hidden");
+  }
+}
+
+function validateForm() {
+  const title = taskTitleInput ? taskTitleInput.value.trim() : "";
+  const owner = taskOwnerInput ? taskOwnerInput.value.trim() : "";
+  const dueDate = taskDueDateInput ? taskDueDateInput.value : "";
+
+  if (title.length < 3) {
+    setFeedback(formFeedbackElement, "El título debe tener al menos 3 caracteres.", "error");
+    return false;
+  }
+
+  if (owner.length < 3) {
+    setFeedback(formFeedbackElement, "El responsable debe tener al menos 3 caracteres.", "error");
+    return false;
+  }
+
+  if (!dueDate) {
+    setFeedback(formFeedbackElement, "Selecciona una fecha límite para la tarea.", "error");
+    return false;
+  }
+
+  return true;
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+
+  if (!currentUserId) {
+    setFeedback(formFeedbackElement, "No se pudo identificar al usuario actual.", "error");
+    return;
+  }
+
+  if (!validateForm()) {
+    return;
+  }
+
+  const payload = {
+    title: taskTitleInput.value.trim(),
+    owner: taskOwnerInput.value.trim(),
+    due_date: taskDueDateInput.value,
+    priority: taskPrioritySelect.value,
+    status: taskStatusSelect.value,
+    description: taskDescriptionInput.value.trim() || null,
+    user_id: currentUserId
+  };
+
+  try {
+    if (editingTaskId) {
+      const { data, error } = await supabaseClient
+        .from("tareas")
+        .update(payload)
+        .eq("id", editingTaskId)
+        .eq("user_id", currentUserId)
+        .select()
+        .maybeSingle();
+
+      if (error) {
+        throw error;
+      }
+
+      setFeedback(formFeedbackElement, "Tarea actualizada correctamente.", "success");
+      await logTaskHistory(editingTaskId, "actualizada");
+    } else {
+      const { data, error } = await supabaseClient
+        .from("tareas")
+        .insert([payload])
+        .select()
+        .maybeSingle();
+
+      if (error) {
+        throw error;
+      }
+
+      setFeedback(formFeedbackElement, "Tarea creada correctamente.", "success");
+
+      if (data && data.id) {
+        await logTaskHistory(data.id, "creada");
+      }
+    }
+
+    resetForm();
+    await fetchTasks();
+  } catch (error) {
+    console.error("Error al guardar la tarea", error);
+    setFeedback(formFeedbackElement, "No fue posible guardar la tarea.", "error");
+  }
+}
+
+async function handleDelete(taskId) {
+  if (!currentUserId) {
+    setFeedback(listFeedbackElement, "No se pudo identificar al usuario actual.", "error");
+    return;
+  }
+
+  const confirmation = window.confirm("¿Deseas eliminar esta tarea?");
+
+  if (!confirmation) {
+    return;
+  }
+
+  try {
+    const { error } = await supabaseClient
+      .from("tareas")
+      .delete()
+      .eq("id", taskId)
+      .eq("user_id", currentUserId);
+
+    if (error) {
+      throw error;
+    }
+
+    if (editingTaskId === taskId) {
+      resetForm();
+    }
+
+    setFeedback(listFeedbackElement, "Tarea eliminada correctamente.", "success");
+    await fetchTasks();
+  } catch (error) {
+    console.error("Error al eliminar la tarea", error);
+    setFeedback(listFeedbackElement, "No fue posible eliminar la tarea.", "error");
+  }
+}
+
+function handleListClick(event) {
+  const actionButton = event.target.closest("[data-action]");
+
+  if (!actionButton || !tasksListElement.contains(actionButton)) {
+    return;
+  }
+
+  const taskId = Number.parseInt(actionButton.dataset.taskId, 10);
+
+  if (!Number.isFinite(taskId)) {
+    return;
+  }
+
+  const task = tasksCache.find((item) => item.id === taskId);
+
+  switch (actionButton.dataset.action) {
+    case "edit": {
+      if (task) {
+        hydrateForm(task);
+        setFeedback(formFeedbackElement, "Listo para editar la tarea seleccionada.", "success");
+      }
+      break;
+    }
+    case "delete": {
+      handleDelete(taskId);
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+}
+
+function registerEventListeners() {
+  if (logoutButton) {
+    logoutButton.addEventListener("click", () => {
+      logout();
+    });
+  }
+
+  if (refreshButton) {
+    refreshButton.addEventListener("click", () => {
+      fetchTasks();
+    });
+  }
+
+  if (taskForm) {
+    taskForm.addEventListener("submit", handleSubmit);
+  }
+
+  if (tasksListElement) {
+    tasksListElement.addEventListener("click", handleListClick);
+  }
+
+  if (cancelEditButton) {
+    cancelEditButton.addEventListener("click", () => {
+      resetForm();
+      setFeedback(formFeedbackElement, "Edición cancelada.");
+    });
+  }
+}
+
+async function initialize() {
+  currentUserId = await resolveCurrentUserId();
+
+  if (!currentUserId) {
+    setFeedback(listFeedbackElement, "No se pudo obtener la sesión del usuario.", "error");
+    setFeedback(formFeedbackElement, "No se pudo obtener la sesión del usuario.", "error");
+    return;
+  }
+
+  await fetchTasks();
+}
+
+registerEventListeners();
+initialize();

--- a/public/css/global.css
+++ b/public/css/global.css
@@ -2,11 +2,11 @@
  * Estilos compartidos opcionales para todo el sistema. */
 
 :root {
-  --color-primary: #38bdf8;
-  --color-primary-dark: #0ea5e9;
-  --color-background: #0f172a;
-  --color-surface: #111c36;
-  --color-text: #e2e8f0;
+  --color-primary: #2563eb;
+  --color-primary-dark: #1d4ed8;
+  --color-background: #ffffff;
+  --color-surface: #f1f5f9;
+  --color-text: #0f172a;
   --border-radius-lg: 16px;
 }
 


### PR DESCRIPTION
## Summary
- replace the dashboard carousel with a vertical two-card task summary and refreshed welcome header copy
- restyle the dashboard to use a two-column layout with white panels, consistent blue actions, and compact spacing
- update the dashboard logic to fetch tasks once and render priority/status chips while wiring module cards to their destinations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc17fda818832d98030283e32ee55e