### PR TITLE
Remove tasks section from dashboard

### DIFF
--- a/modules/dashboard/css/dashboard.css
+++ b/modules/dashboard/css/dashboard.css
@@ -63,45 +63,6 @@ body {
   color: #ffffff;
 }
 
-.dashboard-kpis {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 24px;
-}
-
-.kpi-card {
-  background: linear-gradient(135deg, #ede9fe, #e0f2fe);
-  border: 1px solid #c4b5fd;
-  border-radius: 20px;
-  padding: 28px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  color: #1e1b4b;
-  overflow: hidden;
-}
-
-.kpi-card__header {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.kpi-label {
-  margin: 0;
-  font-size: 0.85rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(30, 27, 75, 0.72);
-}
-
-.kpi-subtitle {
-  margin: 0;
-  font-size: 1.1rem;
-  color: #312e81;
-  font-weight: 600;
-}
-
 .modules-grid {
   display: grid;
   gap: 24px;

--- a/modules/dashboard/index.html
+++ b/modules/dashboard/index.html
@@ -6,7 +6,6 @@
     <title>Dashboard - Sistema Modular</title>
     <link rel="stylesheet" href="../../public/css/global.css" />
     <link rel="stylesheet" href="./css/dashboard.css" />
-    <link rel="stylesheet" href="./css/dashboard-carousel.css" />
   </head>
   <body>
     <main class="dashboard-container">
@@ -19,73 +18,6 @@
           <button id="logoutButton" class="logout-button">Cerrar sesión</button>
         </div>
       </header>
-
-      <section class="dashboard-kpis">
-        <section
-          class="tasks-card"
-          id="tasksCarousel"
-          role="region"
-          aria-label="Tareas asignadas"
-          data-ready="false"
-        >
-          <header class="tasks-card__header">
-            <div class="tasks-card__intro">
-              <p class="kpi-label">Tareas asignadas</p>
-              <h2 class="tasks-card__title">Planifica tu siguiente movimiento</h2>
-              <p class="tasks-card__subtitle">
-                Monitorea responsables, prioridades y fechas límite sin salir del dashboard.
-              </p>
-            </div>
-            <a class="tasks-card__cta" id="tasksCarouselAllButton" href="../tareas/index.html">
-              Ver todas las tareas
-            </a>
-          </header>
-          <div class="tasks-card__inner">
-            <button
-              class="carousel-btn prev"
-              id="tasksCarouselPrev"
-              type="button"
-              aria-label="Anterior"
-              data-carousel-prev
-              disabled
-            >
-              &#10094;
-            </button>
-            <div
-              class="carousel-viewport"
-              id="tasksCarouselViewport"
-              data-carousel-viewport
-              tabindex="0"
-              role="group"
-              aria-roledescription="carrusel"
-              aria-live="polite"
-            >
-              <ul
-                class="carousel-track"
-                id="tasksCarouselTrack"
-                data-carousel-track
-                role="list"
-              ></ul>
-              <p class="carousel-status" id="tasksCarouselStatus" data-carousel-status>
-                Cargando tus tareas...
-              </p>
-            </div>
-            <button
-              class="carousel-btn next"
-              id="tasksCarouselNext"
-              type="button"
-              aria-label="Siguiente"
-              data-carousel-next
-              disabled
-            >
-              &#10095;
-            </button>
-            <div class="carousel-indicators" id="tasksCarouselIndicators" aria-hidden="true">
-              <span class="counter"><span class="current">1</span> / <span class="total">0</span></span>
-            </div>
-          </div>
-        </section>
-      </section>
 
       <section class="modules-grid">
         <a class="module-card" href="../costos/index.html" data-module="costos">
@@ -102,7 +34,6 @@
     </main>
     <script type="module" src="../../lib/supabaseClient.js"></script>
     <script type="module" src="../../lib/authGuard.js"></script>
-    <script type="module" src="./js/dashboard-carousel.js"></script>
     <script type="module" src="./js/dashboard.js"></script>
   </body>
 </html>

--- a/modules/dashboard/js/dashboard.js
+++ b/modules/dashboard/js/dashboard.js
@@ -1,21 +1,10 @@
 // dashboard.js
 // Administra la vista principal tras un inicio de sesión válido.
 
-import {
-  requireAuth,
-  getCurrentUsername,
-  logout,
-  resolveCurrentUserId
-} from "../../../lib/authGuard.js";
-import { supabaseClient } from "../../../lib/supabaseClient.js";
-import { initTasksCarousel } from "./dashboard-carousel.js";
-
+import { requireAuth, getCurrentUsername, logout } from "../../../lib/authGuard.js";
 const usernameDisplay = document.querySelector("#usernameDisplay");
 const logoutButton = document.querySelector("#logoutButton");
 const moduleCards = document.querySelectorAll(".module-card");
-const tasksCarouselAllButton = document.querySelector("#tasksCarouselAllButton");
-
-const tasksCarousel = initTasksCarousel({ containerSelector: "#tasksCarousel" });
 
 // Obtiene y coloca el nombre del usuario autenticado en la cabecera.
 function loadUsername() {
@@ -51,48 +40,11 @@ function configureModuleCards() {
   });
 }
 
-// Solicita las tareas al backend y las procesa para el carrusel.
-async function loadTasksCarousel() {
-  if (!tasksCarousel) {
-    return;
-  }
-
-  tasksCarousel.showLoading();
-
-  const userId = await resolveCurrentUserId();
-
-  if (!userId) {
-    tasksCarousel.showMessage("No se pudo obtener tu información de usuario.", { tone: "error" });
-    return;
-  }
-
-  try {
-    const { data, error } = await supabaseClient
-      .from("tareas")
-      .select("id, title, description, owner, priority, status, due_date")
-      .eq("user_id", userId)
-      .order("due_date", { ascending: true });
-
-    if (error) {
-      throw error;
-    }
-
-    tasksCarousel.setSlides(Array.isArray(data) ? data : []);
-  } catch (error) {
-    console.error("Error al cargar las tareas del dashboard", error);
-    tasksCarousel.showMessage("No fue posible cargar tus tareas.", { tone: "error" });
-  }
-}
-
 function registerEventListeners() {
   if (logoutButton) {
     logoutButton.addEventListener("click", () => {
       logout();
     });
-  }
-
-  if (tasksCarouselAllButton) {
-    tasksCarouselAllButton.setAttribute("href", "../tareas/index.html");
   }
 }
 
@@ -100,4 +52,3 @@ requireAuth();
 loadUsername();
 configureModuleCards();
 registerEventListeners();
-loadTasksCarousel();


### PR DESCRIPTION
## Summary
- remove the tareas carousel from the dashboard layout
- simplify dashboard scripts by dropping task loading logic and dependencies
- clean up dashboard styles now that the task section is gone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd657b1c34832d8409d5d24953abb7