### PR TITLE
feat: refresh login branding and favicon support

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,15 +4,26 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Login - Sistema Modular</title>
+    <link rel="icon" type="image/svg+xml" href="./public/img/portal-digital-favicon.svg" />
     <link rel="stylesheet" href="./public/css/global.css" />
     <link rel="stylesheet" href="./modules/auth/css/login.css" />
   </head>
   <body>
     <main class="login-container">
       <section class="login-card">
-        <header>
-          <h2>Acceso al Sistema</h2>
-          <p>Ingresa tus credenciales para continuar</p>
+        <header class="login-header">
+          <img
+            src="./public/img/portal-digital-logo.svg"
+            alt="Portal Digital Pymess"
+            class="login-logo"
+            width="180"
+            height="120"
+          />
+          <div class="login-header__copy">
+            <h1 class="login-title">Portal Digital PyMEs</h1>
+            <h2>Acceso al Sistema</h2>
+            <p>Ingresa tus credenciales para continuar</p>
+          </div>
         </header>
         <form id="loginForm" novalidate>
           <div class="form-group">

--- a/lib/authGuard.js
+++ b/lib/authGuard.js
@@ -63,6 +63,9 @@ export function saveSession(user, rememberMe) {
     loginAt: new Date().toISOString()
   };
 
+  window.localStorage.removeItem(SESSION_STORAGE_KEY);
+  window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+
   if (rememberMe === true) {
     window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(sessionData));
   } else {

--- a/modules/auth/css/login.css
+++ b/modules/auth/css/login.css
@@ -2,49 +2,87 @@
  * Estilos dedicados para la pantalla de inicio de sesión. */
 
 body {
-  background-color: var(--color-background, #ffffff);
+  --login-bg: radial-gradient(circle at top, rgba(37, 99, 235, 0.16), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(72, 199, 255, 0.18), transparent 50%),
+    #f8fbff;
+  background: var(--login-bg);
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
   color: #1f2937;
+  padding: 24px;
 }
 
 .login-container {
   width: 100%;
   display: flex;
   justify-content: center;
-  padding: 48px 16px;
+  padding: 24px 16px;
 }
 
 .login-card {
   background-color: #ffffff;
   padding: 48px 44px;
-  border-radius: 26px;
-  width: min(430px, 100%);
+  border-radius: 28px;
+  width: min(480px, 100%);
   margin: 0 auto;
-  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.08);
-  border: 1px solid #ecf1ff;
+  box-shadow: 0 24px 68px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(37, 99, 235, 0.16);
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 32px;
+  position: relative;
+  overflow: hidden;
 }
 
-.login-card header {
-  margin-bottom: 12px;
+.login-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), transparent 40%);
+  pointer-events: none;
+}
+
+.login-header {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 24px;
+  align-items: center;
+}
+
+.login-logo {
+  width: 140px;
+  height: auto;
+  filter: drop-shadow(0 12px 24px rgba(37, 99, 235, 0.18));
+}
+
+.login-header__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.login-title {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.34em;
+  text-transform: uppercase;
+  color: #1d4ed8;
+  font-weight: 700;
 }
 
 .login-card h2 {
-  margin: 0 0 6px;
-  font-size: 30px;
+  margin: 0;
+  font-size: 28px;
   font-weight: 700;
-  color: #111827;
+  color: #0f172a;
 }
 
 .login-card p {
   margin: 0;
   color: #4b5563;
-  font-size: 0.98rem;
+  font-size: 1rem;
 }
 
 
@@ -87,55 +125,108 @@ body {
   align-items: center;
   justify-content: space-between;
   margin-bottom: 12px;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .checkbox {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 10px;
-  color: #4b5563;
+  color: #1f2937;
   font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
 }
 
 .checkbox input {
-  width: 18px;
-  height: 18px;
-  accent-color: #2563eb;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  border: 2px solid #c2d3ff;
+  display: grid;
+  place-items: center;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.checkbox input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.28);
+  border-color: #2563eb;
+}
+
+.checkbox input::after {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  transform: scale(0);
+  transition: transform 0.2s ease;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+}
+
+.checkbox input:checked {
+  border-color: transparent;
+  background: rgba(37, 99, 235, 0.12);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.16);
+}
+
+.checkbox input:checked::after {
+  transform: scale(1);
+}
+
+.checkbox span {
+  transition: color 0.2s ease;
+}
+
+.checkbox:hover span {
+  color: #1d4ed8;
 }
 
 .link {
   color: #2563eb;
   text-decoration: none;
   font-weight: 600;
+  transition: color 0.2s ease;
 }
 
 .link:hover {
+  color: #1d4ed8;
   text-decoration: underline;
 }
 
 .link:focus {
-  outline: 2px solid rgba(37, 99, 235, 0.2);
-  outline-offset: 3px;
+  outline: 2px solid rgba(37, 99, 235, 0.3);
+  outline-offset: 4px;
   border-radius: 4px;
 }
 
 
 .primary-button {
   width: 100%;
-  padding: 14px;
-  border-radius: 14px;
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  padding: 16px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
   border: none;
   color: #ffffff;
   font-weight: 700;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 18px 30px rgba(37, 99, 235, 0.25);
+  box-shadow: 0 18px 34px rgba(37, 99, 235, 0.28);
+  font-size: 1.02rem;
+  letter-spacing: 0.03em;
 }
 
 .primary-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 20px 34px rgba(37, 99, 235, 0.35);
+  box-shadow: 0 22px 36px rgba(37, 99, 235, 0.35);
+}
+
+.primary-button:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.28);
 }
 
 .feedback {
@@ -146,14 +237,15 @@ body {
   color: #dc2626;
 }
 
+
 .module-kpi {
-  background-color: #f3f6ff;
-  border-radius: 18px;
-  padding: 22px 24px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(72, 199, 255, 0.12));
+  border-radius: 20px;
+  padding: 24px 26px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  border: 1px solid #e0e7ff;
+  gap: 16px;
+  border: 1px solid rgba(37, 99, 235, 0.18);
 }
 
 .module-kpi h3 {
@@ -223,11 +315,44 @@ body {
 }
 
 @media (max-width: 960px) {
-  .login-container {
-    padding: 24px 16px;
+  body {
+    padding: 16px;
   }
 
   .login-card {
-    padding: 36px 28px;
+    padding: 40px 28px;
+  }
+
+  .login-header {
+    grid-template-columns: 1fr;
+    text-align: center;
+    justify-items: center;
+  }
+
+  .login-header__copy {
+    align-items: center;
+  }
+
+  .login-title {
+    letter-spacing: 0.3em;
+  }
+}
+
+@media (max-width: 520px) {
+  .login-card {
+    padding: 32px 22px;
+    gap: 26px;
+  }
+
+  .form-group input {
+    padding: 12px 14px;
+  }
+
+  .primary-button {
+    padding: 14px;
+  }
+
+  .module-kpi {
+    padding: 20px;
   }
 }

--- a/modules/auth/js/login.js
+++ b/modules/auth/js/login.js
@@ -23,6 +23,8 @@ let navigationHandler = (relativeTarget) => {
   gotoFromModule(import.meta.url, relativeTarget);
 };
 
+const SESSION_STORAGE_KEY = "sistemaModularSesion";
+
 const ACTIVE_MODULES = [
   {
     name: "Costos",
@@ -33,11 +35,6 @@ const ACTIVE_MODULES = [
     name: "Estrategias de Ventas",
     description: "Diseña campañas comerciales con métricas claras y accionables.",
     icon: "🚀"
-  },
-  {
-    name: "Gestión de Tareas",
-    description: "Organiza pendientes, responsables y fechas límite por proyecto.",
-    icon: "🗒️"
   },
   {
     name: "CRM Pro PYME",
@@ -85,7 +82,34 @@ export function initializeForm(feedbackElements = {}) {
     generalElement.textContent = "";
   }
 
+  hydrateRememberPreferences();
   startModuleRotation();
+}
+
+function hydrateRememberPreferences(storageKey = SESSION_STORAGE_KEY) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const storedSessionRaw = window.localStorage.getItem(storageKey);
+
+  if (!storedSessionRaw) {
+    return;
+  }
+
+  try {
+    const storedSession = JSON.parse(storedSessionRaw);
+
+    if (storedSession && storedSession.username && usernameInput) {
+      usernameInput.value = storedSession.username;
+    }
+
+    if (rememberMeInput) {
+      rememberMeInput.checked = true;
+    }
+  } catch (error) {
+    console.warn("No fue posible restaurar las preferencias del usuario.", error);
+  }
 }
 
 // Valida si el username cumple los criterios.

--- a/modules/auth/login.html
+++ b/modules/auth/login.html
@@ -4,15 +4,26 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Login - Sistema Modular</title>
+    <link rel="icon" type="image/svg+xml" href="../../public/img/portal-digital-favicon.svg" />
     <link rel="stylesheet" href="../../public/css/global.css" />
     <link rel="stylesheet" href="./css/login.css" />
   </head>
   <body>
     <main class="login-container">
       <section class="login-card">
-        <header>
-          <h2>Acceso al Sistema</h2>
-          <p>Ingresa tus credenciales para continuar</p>
+        <header class="login-header">
+          <img
+            src="../../public/img/portal-digital-logo.svg"
+            alt="Portal Digital Pymess"
+            class="login-logo"
+            width="180"
+            height="120"
+          />
+          <div class="login-header__copy">
+            <h1 class="login-title">Portal Digital PyMEs</h1>
+            <h2>Acceso al Sistema</h2>
+            <p>Ingresa tus credenciales para continuar</p>
+          </div>
         </header>
         <form id="loginForm" novalidate>
           <div class="form-group">

--- a/modules/auth/register.html
+++ b/modules/auth/register.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Registro - Sistema Modular</title>
+    <link rel="icon" type="image/svg+xml" href="../../public/img/portal-digital-favicon.svg">
     <link rel="stylesheet" href="../../public/css/global.css">
     <link rel="stylesheet" href="./css/register.css">
   </head>

--- a/modules/catalogo/index.html
+++ b/modules/catalogo/index.html
@@ -4,8 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sistema PyME - Mi Negocio</title>
+    <link rel="icon" type="image/svg+xml" href="../../public/img/portal-digital-favicon.svg">
     <link rel="stylesheet" href="./css/catalogo.css">
-    
+
 </head>
 <body>
     <div class="container">

--- a/modules/costos/index.html
+++ b/modules/costos/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sistema de Gestión Financiera para Negocios</title>
+    <link rel="icon" type="image/svg+xml" href="../../public/img/portal-digital-favicon.svg" />
     <link rel="stylesheet" href="../../public/css/global.css" />
     <link rel="stylesheet" href="./css/costos.css" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js" defer></script>

--- a/modules/crm-pro/index.html
+++ b/modules/crm-pro/index.html
@@ -6,6 +6,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <title>CRM Pro PYME - Sistema Offline Permanente</title>
+    <link rel="icon" type="image/svg+xml" href="../../public/img/portal-digital-favicon.svg" />
     <link rel="stylesheet" href="../../public/css/global.css" />
     <style>
         * {

--- a/modules/dashboard/index.html
+++ b/modules/dashboard/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard - Sistema Modular</title>
+    <link rel="icon" type="image/svg+xml" href="../../public/img/portal-digital-favicon.svg" />
     <link rel="stylesheet" href="../../public/css/global.css" />
     <link rel="stylesheet" href="./css/dashboard.css" />
   </head>

--- a/modules/estrategias/index.html
+++ b/modules/estrategias/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Plataforma de Estrategia de Marketing PYME</title>
+    <link rel="icon" type="image/svg+xml" href="../../public/img/portal-digital-favicon.svg">
     <link rel="stylesheet" href="../../public/css/global.css">
     <link rel="stylesheet" href="./css/estrategias.css">
   </head>

--- a/modules/herramientas-extras/index.html
+++ b/modules/herramientas-extras/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dashboard Marketing Digital - PYME</title>
+    <link rel="icon" type="image/svg+xml" href="../../public/img/portal-digital-favicon.svg">
     <link rel="stylesheet" href="../../public/css/global.css">
     <link rel="stylesheet" href="./css/herramientas-extras.css">
 </head>

--- a/modules/tareas/index.html
+++ b/modules/tareas/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gestión de Tareas - Sistema Modular</title>
+    <link rel="icon" type="image/svg+xml" href="../../public/img/portal-digital-favicon.svg" />
     <link rel="stylesheet" href="../../public/css/global.css" />
     <link rel="stylesheet" href="./css/tasks.css" />
   </head>

--- a/public/img/portal-digital-favicon.svg
+++ b/public/img/portal-digital-favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Portal Digital Pymess icon">
+  <defs>
+    <linearGradient id="faviconGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#48c7ff" />
+      <stop offset="1" stop-color="#0077ff" />
+    </linearGradient>
+  </defs>
+  <circle cx="64" cy="64" r="52" fill="none" stroke="url(#faviconGradient)" stroke-width="10" />
+  <ellipse cx="64" cy="64" rx="52" ry="22" transform="rotate(-18 64 64)" fill="none" stroke="#48c7ff" stroke-width="8" />
+  <ellipse cx="64" cy="64" rx="52" ry="22" transform="rotate(18 64 64)" fill="none" stroke="#48c7ff" stroke-width="8" />
+  <ellipse cx="64" cy="64" rx="28" ry="58" fill="none" stroke="#48c7ff" stroke-width="8" />
+  <circle cx="36" cy="44" r="7" fill="#48c7ff" />
+  <circle cx="92" cy="46" r="7" fill="#48c7ff" />
+  <circle cx="44" cy="84" r="7" fill="#48c7ff" />
+  <circle cx="88" cy="92" r="7" fill="#48c7ff" />
+</svg>

--- a/public/img/portal-digital-logo.svg
+++ b/public/img/portal-digital-logo.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 220" role="img" aria-labelledby="title desc">
+  <title id="title">Portal Digital Pymess logo</title>
+  <desc id="desc">Minimal blue illustration of a globe with orbital paths and the text Portal Digital Pymess</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#48c7ff" />
+      <stop offset="1" stop-color="#0077ff" />
+    </linearGradient>
+    <style>
+      .word-mark { font-family: 'Poppins', 'Segoe UI', sans-serif; letter-spacing: 0.28em; text-transform: uppercase; }
+    </style>
+  </defs>
+  <g fill="none" stroke="url(#gradient)" stroke-width="6" stroke-linecap="round">
+    <circle cx="160" cy="92" r="62" />
+    <ellipse cx="160" cy="92" rx="98" ry="38" transform="rotate(-14 160 92)" />
+    <ellipse cx="160" cy="92" rx="98" ry="38" transform="rotate(14 160 92)" />
+    <ellipse cx="160" cy="92" rx="52" ry="100" />
+  </g>
+  <g fill="#48c7ff">
+    <circle cx="97" cy="63" r="8" />
+    <circle cx="220" cy="65" r="8" />
+    <circle cx="118" cy="120" r="8" />
+    <circle cx="214" cy="132" r="8" />
+  </g>
+  <g fill="#091c3a" text-anchor="middle">
+    <text x="160" y="190" font-size="28" font-family="'Poppins','Segoe UI',sans-serif" font-weight="600" letter-spacing="0.18em">PORTAL DIGITAL</text>
+    <text x="160" y="214" font-size="18" font-family="'Poppins','Segoe UI',sans-serif" letter-spacing="0.34em">PYMESS</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add branded login header, gradient styling, and remember me hydration on load
- ensure remember me persistence by clearing stale sessions and removing the tareas module from the KPI rotation
- add reusable logo and favicon assets and reference the favicon across modules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deb64aa4e0832da2cc33d740448c4e